### PR TITLE
Update target and compileSdkVersion to 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
+    compileSdkVersion 33
     defaultConfig {
         applicationId "org.kochka.android.weightlogger"
-        minSdkVersion 14
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 33
     }
 
     buildTypes {


### PR DESCRIPTION
In order to update the app on the Google Play Store, it is necessary to target SDK version 33 or 34. This PR updates the target SDK version and the min SDK version to resolve the issues raised in #71.

Changes:
- Update target and compileSdkVersion to 33
- Update minSdkVersion to 21
- Remove unnecessary buildToolsVersion directive