### PR TITLE
Update dependencies and target SDK version to allow upload to Google Play

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,17 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    namespace "org.kochka.android.weightlogger"
+    compileSdk 34
     defaultConfig {
         applicationId "org.kochka.android.weightlogger"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 35
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildTypes {
@@ -15,33 +21,38 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
-
     packagingOptions {
-        exclude 'META-INF/DEPENDENCIES'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/NOTICE.txt'
+        resources {
+            excludes += ['META-INF/DEPENDENCIES', 'META-INF/NOTICE', 'META-INF/LICENSE', 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt']
+        }
     }
 
-    lintOptions {
-        checkReleaseBuilds false
-        // Or, if you prefer, you can continue to check for errors in release builds,
-        // but continue the build even when errors are found:
+    lint {
         abortOnError false
+        checkReleaseBuilds false
     }
+    buildToolsVersion '35.0.0'
+
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:28.0.0'
-    compile 'com.android.support:design:28.0.0'
-    compile 'com.google.android.gms:play-services-fitness:16.0.1'
-    compile 'cz.msebera.android:httpclient:4.5.8'
-    compile project(':viewflow')
-    compile files('libs/fit.jar')
-    compile files('libs/antpluginlib.jar')
-    compile files('libs/hmmapiwsble.jar')
-    compile 'com.jjoe64:graphview:4.2.2'
-    compile 'org.apache.httpcomponents:httpcore:4.4.10'
-    compile 'org.apache.httpcomponents:httpmime:4.5.6'
+    constraints {
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22") {
+            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
+        }
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22") {
+            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
+        }
+    }
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation("com.google.android.material:material:1.12.0")
+    implementation 'com.google.android.gms:play-services-fitness:21.2.0'
+    implementation 'cz.msebera.android:httpclient:4.5.8'
+    implementation project(':viewflow')
+    implementation files('libs/fit.jar')
+    implementation files('libs/antpluginlib.jar')
+    implementation files('libs/hmmapiwsble.jar')
+    implementation 'com.jjoe64:graphview:4.2.2'
+    implementation 'org.apache.httpcomponents:httpcore:4.4.16'
+    implementation 'org.apache.httpcomponents:httpmime:4.5.14'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
       package="org.kochka.android.weightlogger"
       android:versionCode="32"
       android:versionName="2.4.2">
-    
+
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -15,7 +16,8 @@
 
     <application android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/Theme.WeightLogger" android:allowBackup="true" android:requestLegacyExternalStorage="true">
         <activity android:name=".WeightLoggerActivity"
-                  android:label="@string/app_name">
+                  android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:tools="http://schemas.android.com/tools"
       package="org.kochka.android.weightlogger"
       android:versionCode="32"
       android:versionName="2.4.2">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29"
+        tools:ignore="ScopedStorage"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/app/src/main/java/org/kochka/android/weightlogger/EditMeasurementActivity.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/EditMeasurementActivity.java
@@ -28,8 +28,9 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.res.ResourcesCompat;
 import android.text.format.DateFormat;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -62,7 +63,7 @@ public class EditMeasurementActivity extends AppCompatActivity {
 
     Toolbar actionBar = (Toolbar) findViewById(R.id.actionbar);
     setSupportActionBar(actionBar);
-    actionBar.setNavigationIcon(getResources().getDrawable(R.drawable.abc_ic_ab_back_material));
+    actionBar.setNavigationIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.baseline_arrow_back_24, getTheme()));
     actionBar.setNavigationOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
@@ -138,15 +139,15 @@ public class EditMeasurementActivity extends AppCompatActivity {
 
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
-    switch (item.getItemId()) {
-      case R.id.item_delete:
-        destroyMeasurement();
-        return true;
-      case R.id.item_save:
-        saveMeasurement();
-        return true;       
+    if (item.getItemId() == R.id.item_delete) {
+      destroyMeasurement();
+      return true;
+    } else if (item.getItemId() == R.id.item_save) {
+      saveMeasurement();
+      return true;
+    } else {
+      return super.onOptionsItemSelected(item);
     }
-    return super.onOptionsItemSelected(item);
   }
   
   private void saveMeasurement() {

--- a/app/src/main/java/org/kochka/android/weightlogger/EditPreferences.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/EditPreferences.java
@@ -19,8 +19,10 @@ import org.kochka.android.weightlogger.fragments.NestedPreferenceFragment;
 import org.kochka.android.weightlogger.fragments.PreferencesFragment;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.res.ResourcesCompat;
+
 import android.view.View;
 
 public class EditPreferences extends AppCompatActivity implements PreferencesFragment.Callback {
@@ -34,7 +36,7 @@ public class EditPreferences extends AppCompatActivity implements PreferencesFra
 
     Toolbar actionBar = (Toolbar) findViewById(R.id.actionbar);
     setSupportActionBar(actionBar);
-    actionBar.setNavigationIcon(getResources().getDrawable(R.drawable.abc_ic_ab_back_material));
+    actionBar.setNavigationIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.baseline_arrow_back_24, getTheme()));
     actionBar.setNavigationOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {

--- a/app/src/main/java/org/kochka/android/weightlogger/GraphActivity.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/GraphActivity.java
@@ -24,8 +24,10 @@ import org.kochka.android.weightlogger.data.Measurement;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.res.ResourcesCompat;
+
 import android.view.ViewTreeObserver;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -50,7 +52,7 @@ public class GraphActivity extends AppCompatActivity {
 
     Toolbar actionBar = (Toolbar) findViewById(R.id.actionbar);
     setSupportActionBar(actionBar);
-    actionBar.setNavigationIcon(getResources().getDrawable(R.drawable.abc_ic_ab_back_material));
+    actionBar.setNavigationIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.baseline_arrow_back_24, getTheme()));
     actionBar.setNavigationOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
@@ -88,23 +90,18 @@ public class GraphActivity extends AppCompatActivity {
       item.setVisible(item.getItemId() != item_id);
     }
 
-    switch (item_id) {
-      case R.id.item_graph_weight:
-        actionBar.setSubtitle(R.string.weight);
-        logo.setImageResource(R.drawable.ic_weight);
-        break;
-      case R.id.item_graph_body_fat:
-        actionBar.setSubtitle(R.string.body_fat);
-        logo.setImageResource(R.drawable.ic_body_fat);
-        break;
-      case R.id.item_graph_body_water:
-        actionBar.setSubtitle(R.string.body_water);
-        logo.setImageResource(R.drawable.ic_body_water);
-        break;
-      case R.id.item_graph_muscle_mass:
-        actionBar.setSubtitle(R.string.muscle_mass);
-        logo.setImageResource(R.drawable.ic_muscle_mass);
-        break;
+    if (item_id == R.id.item_graph_weight) {
+      actionBar.setSubtitle(R.string.weight);
+      logo.setImageResource(R.drawable.ic_weight);
+    } else if (item_id == R.id.item_graph_body_fat) {
+      actionBar.setSubtitle(R.string.body_fat);
+      logo.setImageResource(R.drawable.ic_body_fat);
+    } else if (item_id == R.id.item_graph_body_water) {
+      actionBar.setSubtitle(R.string.body_water);
+      logo.setImageResource(R.drawable.ic_body_water);
+    } else if (item_id == R.id.item_graph_muscle_mass) {
+      actionBar.setSubtitle(R.string.muscle_mass);
+      logo.setImageResource(R.drawable.ic_muscle_mass);
     }
     
     // Load data
@@ -117,22 +114,19 @@ public class GraphActivity extends AppCompatActivity {
     for (int i=0; i < measurements.size(); i++) {
       measurement = measurements.get(i);
       dt = measurement.getRecordedAt().getTime().getTime();
-      switch (item_id) {
-        case R.id.item_graph_weight:
-          data.add(new DataPoint(dt, measurement.getConvertedWeight()));
-          break;
-        case R.id.item_graph_body_fat:
-          if (measurement.getBodyFat() != null)
-            data.add(new DataPoint(dt, measurement.getBodyFat()));
-          break;
-        case R.id.item_graph_body_water:
-          if (measurement.getBodyWater() != null)
-            data.add(new DataPoint(dt, measurement.getBodyWater()));
-          break;
-        case R.id.item_graph_muscle_mass:
-          if (measurement.getMuscleMass() != null)
-            data.add(new DataPoint(dt, measurement.getConvertedMuscleMass()));
-          break;
+
+      if (item_id == R.id.item_graph_weight) {
+        data.add(new DataPoint(dt, measurement.getConvertedWeight()));
+      } else if (item_id == R.id.item_graph_body_fat) {
+        if (measurement.getBodyFat() != null)
+          data.add(new DataPoint(dt, measurement.getBodyFat()));
+      }
+      else if (item_id == R.id.item_graph_body_water) {
+        if (measurement.getBodyWater() != null)
+          data.add(new DataPoint(dt, measurement.getBodyWater()));
+      } else if (item_id == R.id.item_graph_muscle_mass) {
+        if (measurement.getMuscleMass() != null)
+          data.add(new DataPoint(dt, measurement.getConvertedMuscleMass()));
       }
     }
 

--- a/app/src/main/java/org/kochka/android/weightlogger/ShowMeasurementActivity.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/ShowMeasurementActivity.java
@@ -19,8 +19,10 @@ import org.kochka.android.weightlogger.adapter.MeasurementsShowAdapter;
 import org.kochka.android.weightlogger.data.Measurement;
 import org.taptwo.android.widget.ViewFlow;
 
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.res.ResourcesCompat;
+
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
@@ -40,7 +42,7 @@ public class ShowMeasurementActivity extends AppCompatActivity {
 
     Toolbar actionBar = (Toolbar) findViewById(R.id.actionbar);
     setSupportActionBar(actionBar);
-    actionBar.setNavigationIcon(getResources().getDrawable(R.drawable.abc_ic_ab_back_material));
+    actionBar.setNavigationIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.baseline_arrow_back_24, getTheme()));
     actionBar.setNavigationOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
@@ -63,8 +65,7 @@ public class ShowMeasurementActivity extends AppCompatActivity {
 
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
-    switch (item.getItemId()) {
-      case R.id.item_edit:
+    if (item.getItemId() == R.id.item_edit) {
         editMeasurement();
         return true;     
     }

--- a/app/src/main/java/org/kochka/android/weightlogger/WeightLoggerActivity.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/WeightLoggerActivity.java
@@ -344,7 +344,7 @@ public class WeightLoggerActivity extends AppCompatActivity implements Permissio
           i.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.export_share_subject));
           i.putExtra(Intent.EXTRA_TEXT, gen_text);
           i.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(new File(Export.path(WeightLoggerActivity.this) + File.separator + filename)));
-          PendingIntent pi = PendingIntent.getActivity(WeightLoggerActivity.this, 0, i, 0);
+          PendingIntent pi = PendingIntent.getActivity(WeightLoggerActivity.this, 0, i, PendingIntent.FLAG_IMMUTABLE);
           
           NotificationCompat.Builder nBuilder = new NotificationCompat.Builder(WeightLoggerActivity.this);
           nBuilder.setSmallIcon(icon);

--- a/app/src/main/java/org/kochka/android/weightlogger/WeightLoggerActivity.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/WeightLoggerActivity.java
@@ -34,10 +34,10 @@ import android.app.NotificationChannel;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.StrictMode;
-import android.support.annotation.NonNull;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
-import android.support.design.widget.FloatingActionButton;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import android.app.AlertDialog;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -49,7 +49,7 @@ import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v4.app.NotificationCompat;
+import androidx.core.app.NotificationCompat;
 import android.util.Log;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
@@ -170,27 +170,15 @@ public class WeightLoggerActivity extends AppCompatActivity implements Permissio
   
   /* Handles menu selections */
   public boolean onOptionsItemSelected(MenuItem item) {
-    switch (item.getItemId()) {
-      case R.id.item_graph:
-        startActivity((new Intent(this, GraphActivity.class)).putExtra("type", "line"));
-        break;
-      case R.id.item_export:
-        export();
-        break;
-      case R.id.item_preferences:
-    	  startActivityForResult(new Intent(this, EditPreferences.class), 0);
-        break;
-      /*
-      case R.id.item_ant:
-        antTest();
-        break;
-      case R.id.item_ble_smartlab:
-        bleTest();
-        break;
-      */
-      case 1:
-        this.finish();
-        return true;
+    if (item.getItemId() == R.id.item_graph) {
+      startActivity((new Intent(this, GraphActivity.class)).putExtra("type", "line"));
+    } else if (item.getItemId() == R.id.item_export) {
+      export();
+    } else if (item.getItemId() == R.id.item_preferences) {
+      startActivityForResult(new Intent(this, EditPreferences.class), 0);
+    } else if (item.getItemId() == 1) {
+      this.finish();
+      return true;
     }
     return(super.onOptionsItemSelected(item));
   }

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/Export.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/Export.java
@@ -30,6 +30,8 @@ import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
+
 import com.garmin.fit.DateTime;
 import com.garmin.fit.FileEncoder;
 import com.garmin.fit.WeightScaleMesg;
@@ -154,7 +156,19 @@ public class Export {
   
   public static String path(Context context) {
     String export_dir = PreferenceManager.getDefaultSharedPreferences(context).getString("export_dir", "/Download/WeightLogger");
-    return Environment.getExternalStorageDirectory().getAbsolutePath() + export_dir;
+    String root_dir = null;
+    File[] ext = ContextCompat.getExternalFilesDirs(context, null);
+    // This if-else block is a little ugly but ensures that we are writing to the correct locations.
+    if (export_dir.equals("$appdata/org.kochka.android.weightlogger/files")) {
+      // The app data folder is now accessed with the following function.
+      return context.getFilesDir().getAbsolutePath();
+    }
+    else if (export_dir.equals("~/Documents/WeightLogger")) {
+      return Environment.getExternalStorageDirectory().getAbsolutePath() + "/Documents/WeightLogger";
+    }
+    else {
+      return Environment.getExternalStorageDirectory().getAbsolutePath() + export_dir;
+    }
   }
   
   private static void checkExternalStorage() throws StorageNotMountedException {

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
@@ -15,7 +15,7 @@
 */
 package org.kochka.android.weightlogger.tools;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.json.JSONObject;
 

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/GoogleFit.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/GoogleFit.java
@@ -89,10 +89,17 @@ public class GoogleFit {
   }
 
   private void buildFitnessClient() {
+    // These URIs were previously defined in Scopes.FITNESS_BODY_READ_WRITE and
+    // Scopes.FITNESS_ACTIVITY_READ_WRITE. Google removed these scopes from their current version of
+    // the APIs. The constants were determined from https://web.archive.org/web/20150909015924/https://developers.google.com/android/reference/com/google/android/gms/common/Scopes
+    // This is a quick fix. The REST API being used here is being removed after 30 June 2025, so
+    // this code will need to be removed soon anyway. See issue #74 (https://github.com/kochka/WeightLogger/issues/74)
+    final String FITNESS_BODY_READ_WRITE = "https://www.googleapis.com/auth/fitness.body.write";
+    final String FITNESS_ACTIVITY_READ_WRITE = "https://www.googleapis.com/auth/fitness.activity.write";
     mClient = new GoogleApiClient.Builder(getContext())
             .addApi(Fitness.HISTORY_API)
-            .addScope(new Scope(Scopes.FITNESS_BODY_READ_WRITE))
-            .addScope(new Scope(Scopes.FITNESS_ACTIVITY_READ_WRITE))
+            .addScope(new Scope(FITNESS_BODY_READ_WRITE))
+            .addScope(new Scope(FITNESS_ACTIVITY_READ_WRITE))
             .addConnectionCallbacks(
                     new GoogleApiClient.ConnectionCallbacks() {
                       @Override

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/PermissionHelper.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/PermissionHelper.java
@@ -2,8 +2,8 @@ package org.kochka.android.weightlogger.tools;
 
 import android.app.Activity;
 import android.content.pm.PackageManager;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
 public class PermissionHelper {
   private static final int PERMISSION_REQUEST_CODE = 1664;

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/PermissionHelper.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/PermissionHelper.java
@@ -1,7 +1,11 @@
 package org.kochka.android.weightlogger.tools;
 
+import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
+
 import android.app.Activity;
 import android.content.pm.PackageManager;
+import android.os.Build;
+
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
@@ -27,7 +31,13 @@ public class PermissionHelper {
   }
 
   public void checkPermission(Activity activity, String permission) {
-    if (ContextCompat.checkSelfPermission(activity, permission) == PackageManager.PERMISSION_GRANTED) {
+    // If we are above the API version where this is required, we have access by default.
+    // This default permission is restrictive but sufficient for our needs.
+    if (permission.equals(WRITE_EXTERNAL_STORAGE) && Build.VERSION.SDK_INT >= 29) {
+      resultListener.onPermissionGranted(permission);
+    }
+    // If we are running on an older API version, we do need this permission
+    else if (ContextCompat.checkSelfPermission(activity, permission) == PackageManager.PERMISSION_GRANTED) {
       resultListener.onPermissionGranted(permission);
     }
     else {

--- a/app/src/main/res/drawable/baseline_arrow_back_24.xml
+++ b/app/src/main/res/drawable/baseline_arrow_back_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+    
+</vector>

--- a/app/src/main/res/layout/actionbar.xml
+++ b/app/src/main/res/layout/actionbar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.Toolbar
+<androidx.appcompat.widget.Toolbar
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:id="@+id/actionbar"
@@ -21,4 +21,4 @@
       android:indeterminate="true"
       android:visibility="gone" />
 
-</android.support.v7.widget.Toolbar>
+</androidx.appcompat.widget.Toolbar>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -6,7 +6,7 @@
                android:layout_width="match_parent"
                android:layout_height="match_parent">
     <ListView android:id="@+id/mListView" style="@style/List" />
-    <android.support.design.widget.FloatingActionButton style="@style/WrapWrap"
+    <com.google.android.material.floatingactionbutton.FloatingActionButton style="@style/WrapWrap"
       android:id="@+id/fab"
       android:layout_gravity="bottom|right"
       android:layout_margin="16dp"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -40,8 +40,8 @@
   </string-array>
 
   <string-array name="export_dir">
-    <item>/WeightLogger</item>
-    <item>/Android/data/org.kochka.android.weightlogger/files</item>
+    <item>~/Documents/WeightLogger</item>
+    <item>$appdata/org.kochka.android.weightlogger/files</item>
     <item>/Download/WeightLogger</item>
     <item>/Download</item>
   </string-array>

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,22 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:8.8.1'
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
+    }
+    configurations.all {
+        resolutionStrategy {
+            force('org.jetbrains.kotlin:kotlin-stdlib:1.8.22')
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 06 19:10:30 CET 2021
+#Sat Feb 15 12:30:27 NZDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/viewflow/build.gradle
+++ b/viewflow/build.gradle
@@ -1,11 +1,16 @@
 apply plugin: 'com.android.library'
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
+    namespace 'org.taptwo.android.widget.viewflow'
+    compileSdk 34
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 30
+        minSdkVersion 21
+        targetSdkVersion 35
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildTypes {
@@ -14,6 +19,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
+    buildToolsVersion '35.0.0'
 }
 
 dependencies {

--- a/viewflow/src/main/AndroidManifest.xml
+++ b/viewflow/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	android:versionCode="1" android:versionName="1.0" package="org.taptwo.android.widget.viewflow">
+	android:versionCode="1" android:versionName="1.0">
 	<application android:icon="@drawable/icon" android:label="@string/app_name">
 	</application>
-	<uses-sdk android:targetSdkVersion="8"/>
 </manifest> 


### PR DESCRIPTION
This PR modernises the codebase, allowing it to target modern versions of Android.

The key changes are:
- Update targetSdkVersion to 35 (ensuring app can be published on Google Play store)
- Migrate android.support libraries to androidx
- Fix build issues resulting from changes to versions and dependencies

Changes were tested on emulators targeting API21, API30 and API35. Tested on physical device running API29. Logging and plotting were tested. Data export was not tested. No issues noted.