### PR TITLE
Fix Garmin Upload Errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,15 +33,18 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:28.0.0'
-    compile 'com.android.support:design:28.0.0'
-    compile 'com.google.android.gms:play-services-fitness:16.0.1'
-    compile 'cz.msebera.android:httpclient:4.5.8'
-    compile project(':viewflow')
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    implementation 'com.google.android.gms:play-services-fitness:16.0.1'
+    implementation 'cz.msebera.android:httpclient:4.5.8'
+    implementation project(':viewflow')
     compile files('libs/fit.jar')
     compile files('libs/antpluginlib.jar')
     compile files('libs/hmmapiwsble.jar')
-    compile 'com.jjoe64:graphview:4.2.2'
-    compile 'org.apache.httpcomponents:httpcore:4.4.10'
-    compile 'org.apache.httpcomponents:httpmime:4.5.6'
+    implementation 'com.jjoe64:graphview:4.2.2'
+    implementation 'org.apache.httpcomponents:httpcore:4.4.10'
+    implementation 'org.apache.httpcomponents:httpmime:4.5.6'
+//    implementation 'com.github.scribejava:scribejava-apis:6.4.1'
+    implementation group: 'oauth.signpost', name: 'signpost-core', version: '2.0.0'
+    implementation group: 'oauth.signpost', name: 'signpost-commonshttp4', version: '2.0.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,17 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    namespace "org.kochka.android.weightlogger"
+    compileSdk 34
     defaultConfig {
         applicationId "org.kochka.android.weightlogger"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 35
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildTypes {
@@ -15,33 +21,38 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
-
     packagingOptions {
-        exclude 'META-INF/DEPENDENCIES'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/NOTICE.txt'
+        resources {
+            excludes += ['META-INF/DEPENDENCIES', 'META-INF/NOTICE', 'META-INF/LICENSE', 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt']
+        }
     }
 
-    lintOptions {
-        checkReleaseBuilds false
-        // Or, if you prefer, you can continue to check for errors in release builds,
-        // but continue the build even when errors are found:
+    lint {
         abortOnError false
+        checkReleaseBuilds false
     }
+    buildToolsVersion '35.0.0'
+
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:28.0.0'
-    compile 'com.android.support:design:28.0.0'
-    compile 'com.google.android.gms:play-services-fitness:16.0.1'
-    compile 'cz.msebera.android:httpclient:4.5.8'
-    compile project(':viewflow')
-    compile files('libs/fit.jar')
-    compile files('libs/antpluginlib.jar')
-    compile files('libs/hmmapiwsble.jar')
-    compile 'com.jjoe64:graphview:4.2.2'
-    compile 'org.apache.httpcomponents:httpcore:4.4.10'
-    compile 'org.apache.httpcomponents:httpmime:4.5.6'
+    constraints {
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22") {
+            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
+        }
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22") {
+            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
+        }
+    }
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation("com.google.android.material:material:1.12.0")
+    implementation 'com.google.android.gms:play-services-fitness:21.2.0'
+    implementation 'cz.msebera.android:httpclient:4.5.8'
+    implementation project(':viewflow')
+    implementation files('libs/fit.jar')
+    implementation files('libs/antpluginlib.jar')
+    implementation files('libs/hmmapiwsble.jar')
+    implementation 'com.jjoe64:graphview:4.2.2'
+    implementation 'org.apache.httpcomponents:httpcore:4.4.16'
+    implementation 'org.apache.httpcomponents:httpmime:4.5.14'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
       package="org.kochka.android.weightlogger"
       android:versionCode="32"
       android:versionName="2.4.2">
-    
+
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -15,7 +16,8 @@
 
     <application android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/Theme.WeightLogger" android:allowBackup="true" android:requestLegacyExternalStorage="true">
         <activity android:name=".WeightLoggerActivity"
-                  android:label="@string/app_name">
+                  android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:tools="http://schemas.android.com/tools"
       package="org.kochka.android.weightlogger"
       android:versionCode="32"
       android:versionName="2.4.2">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29"
+        tools:ignore="ScopedStorage"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/app/src/main/java/org/kochka/android/weightlogger/EditMeasurementActivity.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/EditMeasurementActivity.java
@@ -28,8 +28,9 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.res.ResourcesCompat;
 import android.text.format.DateFormat;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -62,7 +63,7 @@ public class EditMeasurementActivity extends AppCompatActivity {
 
     Toolbar actionBar = (Toolbar) findViewById(R.id.actionbar);
     setSupportActionBar(actionBar);
-    actionBar.setNavigationIcon(getResources().getDrawable(R.drawable.abc_ic_ab_back_material));
+    actionBar.setNavigationIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.baseline_arrow_back_24, getTheme()));
     actionBar.setNavigationOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
@@ -138,15 +139,15 @@ public class EditMeasurementActivity extends AppCompatActivity {
 
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
-    switch (item.getItemId()) {
-      case R.id.item_delete:
-        destroyMeasurement();
-        return true;
-      case R.id.item_save:
-        saveMeasurement();
-        return true;       
+    if (item.getItemId() == R.id.item_delete) {
+      destroyMeasurement();
+      return true;
+    } else if (item.getItemId() == R.id.item_save) {
+      saveMeasurement();
+      return true;
+    } else {
+      return super.onOptionsItemSelected(item);
     }
-    return super.onOptionsItemSelected(item);
   }
   
   private void saveMeasurement() {

--- a/app/src/main/java/org/kochka/android/weightlogger/EditPreferences.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/EditPreferences.java
@@ -19,8 +19,10 @@ import org.kochka.android.weightlogger.fragments.NestedPreferenceFragment;
 import org.kochka.android.weightlogger.fragments.PreferencesFragment;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.res.ResourcesCompat;
+
 import android.view.View;
 
 public class EditPreferences extends AppCompatActivity implements PreferencesFragment.Callback {
@@ -34,7 +36,7 @@ public class EditPreferences extends AppCompatActivity implements PreferencesFra
 
     Toolbar actionBar = (Toolbar) findViewById(R.id.actionbar);
     setSupportActionBar(actionBar);
-    actionBar.setNavigationIcon(getResources().getDrawable(R.drawable.abc_ic_ab_back_material));
+    actionBar.setNavigationIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.baseline_arrow_back_24, getTheme()));
     actionBar.setNavigationOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {

--- a/app/src/main/java/org/kochka/android/weightlogger/GraphActivity.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/GraphActivity.java
@@ -24,8 +24,10 @@ import org.kochka.android.weightlogger.data.Measurement;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.res.ResourcesCompat;
+
 import android.view.ViewTreeObserver;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -50,7 +52,7 @@ public class GraphActivity extends AppCompatActivity {
 
     Toolbar actionBar = (Toolbar) findViewById(R.id.actionbar);
     setSupportActionBar(actionBar);
-    actionBar.setNavigationIcon(getResources().getDrawable(R.drawable.abc_ic_ab_back_material));
+    actionBar.setNavigationIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.baseline_arrow_back_24, getTheme()));
     actionBar.setNavigationOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
@@ -88,23 +90,18 @@ public class GraphActivity extends AppCompatActivity {
       item.setVisible(item.getItemId() != item_id);
     }
 
-    switch (item_id) {
-      case R.id.item_graph_weight:
-        actionBar.setSubtitle(R.string.weight);
-        logo.setImageResource(R.drawable.ic_weight);
-        break;
-      case R.id.item_graph_body_fat:
-        actionBar.setSubtitle(R.string.body_fat);
-        logo.setImageResource(R.drawable.ic_body_fat);
-        break;
-      case R.id.item_graph_body_water:
-        actionBar.setSubtitle(R.string.body_water);
-        logo.setImageResource(R.drawable.ic_body_water);
-        break;
-      case R.id.item_graph_muscle_mass:
-        actionBar.setSubtitle(R.string.muscle_mass);
-        logo.setImageResource(R.drawable.ic_muscle_mass);
-        break;
+    if (item_id == R.id.item_graph_weight) {
+      actionBar.setSubtitle(R.string.weight);
+      logo.setImageResource(R.drawable.ic_weight);
+    } else if (item_id == R.id.item_graph_body_fat) {
+      actionBar.setSubtitle(R.string.body_fat);
+      logo.setImageResource(R.drawable.ic_body_fat);
+    } else if (item_id == R.id.item_graph_body_water) {
+      actionBar.setSubtitle(R.string.body_water);
+      logo.setImageResource(R.drawable.ic_body_water);
+    } else if (item_id == R.id.item_graph_muscle_mass) {
+      actionBar.setSubtitle(R.string.muscle_mass);
+      logo.setImageResource(R.drawable.ic_muscle_mass);
     }
     
     // Load data
@@ -117,22 +114,19 @@ public class GraphActivity extends AppCompatActivity {
     for (int i=0; i < measurements.size(); i++) {
       measurement = measurements.get(i);
       dt = measurement.getRecordedAt().getTime().getTime();
-      switch (item_id) {
-        case R.id.item_graph_weight:
-          data.add(new DataPoint(dt, measurement.getConvertedWeight()));
-          break;
-        case R.id.item_graph_body_fat:
-          if (measurement.getBodyFat() != null)
-            data.add(new DataPoint(dt, measurement.getBodyFat()));
-          break;
-        case R.id.item_graph_body_water:
-          if (measurement.getBodyWater() != null)
-            data.add(new DataPoint(dt, measurement.getBodyWater()));
-          break;
-        case R.id.item_graph_muscle_mass:
-          if (measurement.getMuscleMass() != null)
-            data.add(new DataPoint(dt, measurement.getConvertedMuscleMass()));
-          break;
+
+      if (item_id == R.id.item_graph_weight) {
+        data.add(new DataPoint(dt, measurement.getConvertedWeight()));
+      } else if (item_id == R.id.item_graph_body_fat) {
+        if (measurement.getBodyFat() != null)
+          data.add(new DataPoint(dt, measurement.getBodyFat()));
+      }
+      else if (item_id == R.id.item_graph_body_water) {
+        if (measurement.getBodyWater() != null)
+          data.add(new DataPoint(dt, measurement.getBodyWater()));
+      } else if (item_id == R.id.item_graph_muscle_mass) {
+        if (measurement.getMuscleMass() != null)
+          data.add(new DataPoint(dt, measurement.getConvertedMuscleMass()));
       }
     }
 

--- a/app/src/main/java/org/kochka/android/weightlogger/ShowMeasurementActivity.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/ShowMeasurementActivity.java
@@ -19,8 +19,10 @@ import org.kochka.android.weightlogger.adapter.MeasurementsShowAdapter;
 import org.kochka.android.weightlogger.data.Measurement;
 import org.taptwo.android.widget.ViewFlow;
 
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.res.ResourcesCompat;
+
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
@@ -40,7 +42,7 @@ public class ShowMeasurementActivity extends AppCompatActivity {
 
     Toolbar actionBar = (Toolbar) findViewById(R.id.actionbar);
     setSupportActionBar(actionBar);
-    actionBar.setNavigationIcon(getResources().getDrawable(R.drawable.abc_ic_ab_back_material));
+    actionBar.setNavigationIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.baseline_arrow_back_24, getTheme()));
     actionBar.setNavigationOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
@@ -63,8 +65,7 @@ public class ShowMeasurementActivity extends AppCompatActivity {
 
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
-    switch (item.getItemId()) {
-      case R.id.item_edit:
+    if (item.getItemId() == R.id.item_edit) {
         editMeasurement();
         return true;     
     }

--- a/app/src/main/java/org/kochka/android/weightlogger/WeightLoggerActivity.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/WeightLoggerActivity.java
@@ -344,7 +344,7 @@ public class WeightLoggerActivity extends AppCompatActivity implements Permissio
           i.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.export_share_subject));
           i.putExtra(Intent.EXTRA_TEXT, gen_text);
           i.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(new File(Export.path(WeightLoggerActivity.this) + File.separator + filename)));
-          PendingIntent pi = PendingIntent.getActivity(WeightLoggerActivity.this, 0, i, 0);
+          PendingIntent pi = PendingIntent.getActivity(WeightLoggerActivity.this, 0, i, PendingIntent.FLAG_IMMUTABLE);
           
           NotificationCompat.Builder nBuilder = new NotificationCompat.Builder(WeightLoggerActivity.this);
           nBuilder.setSmallIcon(icon);

--- a/app/src/main/java/org/kochka/android/weightlogger/WeightLoggerActivity.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/WeightLoggerActivity.java
@@ -34,10 +34,10 @@ import android.app.NotificationChannel;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.StrictMode;
-import android.support.annotation.NonNull;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
-import android.support.design.widget.FloatingActionButton;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import android.app.AlertDialog;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -49,7 +49,7 @@ import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v4.app.NotificationCompat;
+import androidx.core.app.NotificationCompat;
 import android.util.Log;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
@@ -170,27 +170,15 @@ public class WeightLoggerActivity extends AppCompatActivity implements Permissio
   
   /* Handles menu selections */
   public boolean onOptionsItemSelected(MenuItem item) {
-    switch (item.getItemId()) {
-      case R.id.item_graph:
-        startActivity((new Intent(this, GraphActivity.class)).putExtra("type", "line"));
-        break;
-      case R.id.item_export:
-        export();
-        break;
-      case R.id.item_preferences:
-    	  startActivityForResult(new Intent(this, EditPreferences.class), 0);
-        break;
-      /*
-      case R.id.item_ant:
-        antTest();
-        break;
-      case R.id.item_ble_smartlab:
-        bleTest();
-        break;
-      */
-      case 1:
-        this.finish();
-        return true;
+    if (item.getItemId() == R.id.item_graph) {
+      startActivity((new Intent(this, GraphActivity.class)).putExtra("type", "line"));
+    } else if (item.getItemId() == R.id.item_export) {
+      export();
+    } else if (item.getItemId() == R.id.item_preferences) {
+      startActivityForResult(new Intent(this, EditPreferences.class), 0);
+    } else if (item.getItemId() == 1) {
+      this.finish();
+      return true;
     }
     return(super.onOptionsItemSelected(item));
   }

--- a/app/src/main/java/org/kochka/android/weightlogger/WeightLoggerActivity.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/WeightLoggerActivity.java
@@ -288,7 +288,7 @@ public class WeightLoggerActivity extends AppCompatActivity implements Permissio
                 if (username.equals("") || password.equals("")) 
                   throw new Exception(getString(R.string.gc_configure_account));
                 this.gc = new GarminConnect();
-                if (!this.gc.signin(username, password))
+                if (!this.gc.signin(username, password, WeightLoggerActivity.this))
                   throw new Exception(getString(R.string.gc_account_error));  
               } else
                 throw new Exception(getString(R.string.network_error));  

--- a/app/src/main/java/org/kochka/android/weightlogger/fragments/PreferencesFragment.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/fragments/PreferencesFragment.java
@@ -17,6 +17,7 @@ package org.kochka.android.weightlogger.fragments;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -68,6 +69,7 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
     ((EditTextPreference) findPreference("age")).getEditText().setInputType(InputType.TYPE_CLASS_NUMBER);
 
     findPreference("optional_fields").setOnPreferenceClickListener(this);
+    findPreference("garmin_token_clear").setOnPreferenceClickListener(this);
     findPreference("db_backup").setOnPreferenceClickListener(this);
     findPreference("db_restore").setOnPreferenceClickListener(this);
     findPreference("db_purge").setOnPreferenceClickListener(this);
@@ -91,7 +93,9 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
   public boolean onPreferenceClick(Preference preference) {
     if (preference.getKey().equals("optional_fields"))
       mCallback.onNestedPreferenceSelected(NestedPreferenceFragment.NESTED_SCREEN_FIELDS);
-    else if (preference.getKey().equals("db_backup"))
+    else if (preference.getKey().equals("garmin_token_clear")) {
+      clearGarminTokens();
+    } else if (preference.getKey().equals("db_backup"))
       dbBackup();
     else if (preference.getKey().equals("db_restore"))
       dbRestore();
@@ -143,6 +147,26 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
             pref.setSummary(sPref.getText());
         }
       }
+    }
+  }
+
+  /* Clear Garmin OAuth Tokens */
+  private void clearGarminTokens() {
+    SharedPreferences authPreferences = getActivity().getSharedPreferences(getActivity().getApplicationContext().getPackageName() + ".garmintokens", Context.MODE_PRIVATE);
+    SharedPreferences.Editor authPreferencesEditor = authPreferences.edit();
+    authPreferencesEditor.remove("garminOauth1Token");
+    authPreferencesEditor.remove("garminOauth1TokenSecret");
+    authPreferencesEditor.remove("garminOauth1MfaToken");
+    authPreferencesEditor.remove("garminOauth1MfaExpirationTimestamp");
+    authPreferencesEditor.remove("garminOauth2Token");
+    authPreferencesEditor.remove("garminOauth2RefreshToken");
+    authPreferencesEditor.remove("garminOauth2ExpiryTimestamp");
+    authPreferencesEditor.remove("garminOauth2RefreshExpiryTimestamp");
+    if (authPreferencesEditor.commit()) {
+      Toast.makeText(getActivity(), R.string.gc_token_cleared, Toast.LENGTH_SHORT).show();
+    }
+    else {
+      Toast.makeText(getActivity(), R.string.gc_token_clear_failed, Toast.LENGTH_SHORT).show();
     }
   }
 

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/Export.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/Export.java
@@ -30,6 +30,8 @@ import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
+
 import com.garmin.fit.DateTime;
 import com.garmin.fit.FileEncoder;
 import com.garmin.fit.WeightScaleMesg;
@@ -154,7 +156,19 @@ public class Export {
   
   public static String path(Context context) {
     String export_dir = PreferenceManager.getDefaultSharedPreferences(context).getString("export_dir", "/Download/WeightLogger");
-    return Environment.getExternalStorageDirectory().getAbsolutePath() + export_dir;
+    String root_dir = null;
+    File[] ext = ContextCompat.getExternalFilesDirs(context, null);
+    // This if-else block is a little ugly but ensures that we are writing to the correct locations.
+    if (export_dir.equals("$appdata/org.kochka.android.weightlogger/files")) {
+      // The app data folder is now accessed with the following function.
+      return context.getFilesDir().getAbsolutePath();
+    }
+    else if (export_dir.equals("~/Documents/WeightLogger")) {
+      return Environment.getExternalStorageDirectory().getAbsolutePath() + "/Documents/WeightLogger";
+    }
+    else {
+      return Environment.getExternalStorageDirectory().getAbsolutePath() + export_dir;
+    }
   }
   
   private static void checkExternalStorage() throws StorageNotMountedException {

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
@@ -15,7 +15,7 @@
 */
 package org.kochka.android.weightlogger.tools;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.json.JSONObject;
 

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
@@ -192,7 +192,7 @@ public class GarminConnect {
   private static final String SSO_SIGNIN_URL = SSO_URL + "/signin";
   private static final String SSO_MFA_URL = SSO_URL + "/verifyMFA/loginEnterMfaCode";
   private static final Pattern LOCATION_PATTERN = Pattern.compile("location: (.*)");
-  private static final String CSRF_TOKEN_PATTERN = "name=\"_csrf\" *value=\"([A-Z0-9]+)\"";
+  private static final String CSRF_TOKEN_PATTERN = "name=\"_csrf\" +value=\"([A-Z0-9]+)\"";
   private static final String TICKET_FINDER_PATTERN = "ticket=([^']+?)\";";
 
   private static final String USER_AGENT = "com.garmin.android.apps.connectmobile";

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
@@ -129,7 +129,6 @@ public class GarminConnect {
   }
 
   public class Oauth2Token {
-    // TODO: include the expiry date, refresh token, and the refresh token expiry
     private String oauth2Token;
     private String oauth2RefreshToken;
     private long timeOfExpiry;
@@ -164,14 +163,11 @@ public class GarminConnect {
     long timeOfExpiry = sharedPreferences.getLong("garminOauth2ExpiryTimestamp",-1);
     long timeOfRefreshExpiry = sharedPreferences.getLong("garminOauth2RefreshExpiryTimestamp",-1);;
 
-    // Check whether the tokens are valid or whether they have expired.
-    if (oauth2Token == "" || oauth2RefreshToken == "" || timeOfRefreshExpiry < currentTime) {
+    if (oauth2Token == "" || timeOfExpiry < currentTime) {
+      // Get a new oauth2 token using the saved oauth1 token.
+      // According to https://github.com/matin/garth/blob/316787d1e3ff69c09725b2eb8ded748a4422abb3/garth/http.py#L167
+      // Garmin Connect also just uses the OAuth1 token to get a new OAuth2 token.
       return  false;
-    }
-
-    if (timeOfExpiry < currentTime) {
-      // TODO: implement refresh logic. For now, just fail gracefully.
-      return false;
     }
 
     this.oauth2Token = new Oauth2Token(oauth2Token,oauth2RefreshToken,timeOfExpiry, timeOfRefreshExpiry);

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
@@ -32,8 +32,12 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.regex.Matcher;
@@ -78,9 +82,9 @@ public class GarminConnect {
     // These member are currently unused. Maybe they can be used to issue a new OAuth1 token without
     // requiring the user to re-enter an MFA code.
     private String mfaToken;
-    private String mfaExpirationTimestamp;
+    private long mfaExpirationTimestamp;
 
-    public OAuth1Token(String oauth1Token, String oauth1TokenSecret, String mfaToken, String mfaExpirationTimestamp) {
+    public OAuth1Token(String oauth1Token, String oauth1TokenSecret, String mfaToken, long mfaExpirationTimestamp) {
       this.oauth1Token = oauth1Token;
       this.oauth1TokenSecret = oauth1TokenSecret;
       this.mfaToken = mfaToken;
@@ -99,7 +103,7 @@ public class GarminConnect {
       return mfaToken;
     }
 
-    public String getMfaTokenExpirationTimestamp() {
+    public long getMfaTokenExpirationTimestamp() {
       return mfaExpirationTimestamp;
     }
 
@@ -108,8 +112,7 @@ public class GarminConnect {
       sharedPreferenceEditor.putString("garminOauth1Token", this.oauth1Token);
       sharedPreferenceEditor.putString("garminOauth1TokenSecret", this.oauth1TokenSecret);
       sharedPreferenceEditor.putString("garminOauth1MfaToken", this.mfaToken);
-      // Todo: should the timestamp be stored as a numeric type?
-      sharedPreferenceEditor.putString("garminOauth1MfaExpirationTimestamp", this.mfaExpirationTimestamp);
+      sharedPreferenceEditor.putLong("garminOauth1MfaExpirationTimestamp", this.mfaExpirationTimestamp);
       return sharedPreferenceEditor.commit();
     }
   }
@@ -119,10 +122,10 @@ public class GarminConnect {
     String token = sharedPreferences.getString("garminOauth1Token","");
     String tokenSecret = sharedPreferences.getString("garminOauth1TokenSecret","");
     String mfaToken = sharedPreferences.getString("garminOauth1MfaToken","");
-    String mfaExpirationTimestamp = sharedPreferences.getString("garminOauth1MfaExpirationTimestamp","");
+    long mfaExpirationTimestamp = sharedPreferences.getLong("garminOauth1MfaExpirationTimestamp",0);
 
-    // Todo: check for timestamp expiry.
-    if (token.isEmpty() || tokenSecret.isEmpty() || mfaToken.isEmpty() || mfaExpirationTimestamp.isEmpty()) {
+    long currentTime = System.currentTimeMillis() / 1000;
+    if (token.isEmpty() || tokenSecret.isEmpty() || mfaExpirationTimestamp < currentTime) {
       return false;
     }
 
@@ -165,7 +168,7 @@ public class GarminConnect {
     long timeOfExpiry = sharedPreferences.getLong("garminOauth2ExpiryTimestamp",-1);
     long timeOfRefreshExpiry = sharedPreferences.getLong("garminOauth2RefreshExpiryTimestamp",-1);;
 
-    if (oauth2Token == "" || timeOfExpiry < currentTime) {
+    if (oauth2Token.isEmpty() || timeOfExpiry < currentTime) {
       // Get a new oauth2 token using the saved oauth1 token.
       // According to https://github.com/matin/garth/blob/316787d1e3ff69c09725b2eb8ded748a4422abb3/garth/http.py#L167
       // Garmin Connect also just uses the OAuth1 token to get a new OAuth2 token.
@@ -243,6 +246,9 @@ public class GarminConnect {
       SharedPreferences authPreferences = currentActivity.getSharedPreferences(currentActivity.getApplicationContext().getPackageName() + ".garmintokens", Context.MODE_PRIVATE);
 
       // If we have an unexpired OAuth2 token then we don't need to go through the login flow.
+      // TODO: Allow user to invalidate stored tokens (or do it automatically). Currently, if the
+      //  tokens are not expired based on the timestamp but are invalid in some way, they will not
+      //  be cleared and the user will be unable to log in.
       if (loadOauth2FromSharedPreferences(authPreferences)) {
         return true;
       }
@@ -329,7 +335,12 @@ public class GarminConnect {
     getOauth1.setHeader(HttpHeaders.REFERER, getLastUri());
     HttpResponse response = httpclient.execute(getOauth1,httpContext);
     String oauth1ResponseAsString = EntityUtils.toString(response.getEntity());
-    this.oauth1Token = getOauth1FromResponse(oauth1ResponseAsString);
+    try {
+      this.oauth1Token = getOauth1FromResponse(oauth1ResponseAsString);
+    }
+    catch (java.text.ParseException e) {
+      return false;
+    }
     return true;
   }
 
@@ -365,7 +376,7 @@ public class GarminConnect {
     return new HttpGet(redirect);
   }
 
-  private OAuth1Token getOauth1FromResponse(String responseAsString) {
+  private OAuth1Token getOauth1FromResponse(String responseAsString) throws java.text.ParseException {
     // Garmin returns a bare query string. Turn it into a dummy URI for parsing.
     Uri uri = Uri.parse("http://invalid?"+responseAsString);
     String oauth1Token = uri.getQueryParameter("oauth_token");
@@ -374,8 +385,11 @@ public class GarminConnect {
     // The following args aren't always present but getQueryParameter will return just null if they
     // aren't.
     String mfaToken = uri.getQueryParameter("mfa_token");
-    String mfaExpirationTimestamp = uri.getQueryParameter("mfa_expiration_timestamp");
-    return new OAuth1Token(oauth1Token,oauth1TokenSecret, mfaToken, mfaExpirationTimestamp);
+    String mfaExpirationTimestampString = uri.getQueryParameter("mfa_expiration_timestamp");
+    SimpleDateFormat mfaExpirationFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US);
+    mfaExpirationFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    Date mfaExpirationTimestamp = mfaExpirationFormat.parse(mfaExpirationTimestampString);
+    return new OAuth1Token(oauth1Token,oauth1TokenSecret, mfaToken, mfaExpirationTimestamp.getTime());
   }
 
   private OAuth2Token getOauth2FromResponse(String responseAsString) throws JSONException {

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
@@ -308,7 +308,11 @@ public class GarminConnect {
 
       // Use the OAuth1 token to get an OAuth2 token.
       consumer.setTokenWithSecret(oauth1Token.getOauth1Token(), oauth1Token.getOauth1TokenSecret());
-      return performOauth2exchange(consumer); // If OAuth2 exchange is successful, we are logged in.
+      if (!performOauth2exchange(consumer)) {
+        // If OAuth2 exchange fails, we cannot upload.
+        return false;
+      }
+      return oauth2Token.saveToSharedPreferences(authPreferences.edit());
 
 
     } catch (Exception e) {

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
@@ -18,6 +18,7 @@ package org.kochka.android.weightlogger.tools;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.text.InputType;
@@ -99,6 +100,18 @@ public class GarminConnect {
     public String getMfaTokenExpirationTimestamp() {
       return mfaExpirationTimestamp;
     }
+
+    public Boolean saveToSharedPreferences(SharedPreferences.Editor sharedPreferenceEditor) {
+      // Todo: support EncryptedSharedPreferences.
+      sharedPreferenceEditor.putString("garminOauth1Token", this.oauth1Token);
+      sharedPreferenceEditor.putString("garminOauth1TokenSecret", this.oauth1TokenSecret);
+      sharedPreferenceEditor.putString("garminOauth1MfaToken", this.mfaToken);
+      // Todo: should the timestamp be stored as a numeric type?
+      sharedPreferenceEditor.putString("garminOauth1MfaExpirationTimestamp", this.getMfaTokenExpirationTimestamp());
+      return sharedPreferenceEditor.commit();
+    }
+
+    // Todo: add ability to load from SharedPreferences.
   }
 
   public class Oauth2Token {

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
@@ -383,7 +383,7 @@ public class GarminConnect {
       OAuth1Token.clearFromSharedPreferences(authPreferences.edit());
       return false;
     }
-    HttpEntity oauth2Entity = httpclient.execute(postOauth2,httpContext).getEntity();
+    HttpEntity oauth2Entity = oauth2Response.getEntity();
 
     String oauth2ResponseAsString = EntityUtils.toString(oauth2Entity);
     try {

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/GarminConnect.java
@@ -63,7 +63,7 @@ public class GarminConnect {
   private static final String OAUTH_CONSUMER_URL = "https://thegarth.s3.amazonaws.com/oauth_consumer.json";
   private static final String OAUTH1_CONSUMER_KEY = "fc3e99d2-118c-44b8-8ae3-03370dde24c0";
   private static final String OAUTH1_CONSUMER_SECRET = "E08WAR897WEy2knn7aFBrvegVAf0AFdWBBF";
-  private static final String GET_OAUTH1_URL = "https://connectapi.garmin.com/oauth-service/oauth/preauthorized?login-url=https://sso.garmin.com/sso/embed&accepts-mfa-tokens=true&ticket=";
+  private static final String GET_OAUTH1_URL = "https://connectapi.garmin.com/oauth-service/oauth/preauthorized?login-url=https://sso.garmin.com/sso/embed";
   private static final String GET_OAUTH2_URL = "https://connectapi.garmin.com/oauth-service/oauth/exchange/user/2.0";
   private static final String FIT_FILE_UPLOAD_URL = "https://connect.garmin.com/upload-service/upload/.fit";
 
@@ -166,12 +166,12 @@ public class GarminConnect {
         consumer.setMessageSigner(new HmacSha1MessageSigner());
 //        consumer.setTokenWithSecret(OAUTH1_CONSUMER_KEY, OAUTH1_CONSUMER_SECRET);
 
-        org.apache.http.client.methods.HttpGet request = new org.apache.http.client.methods.HttpGet(GET_OAUTH1_URL + ticket);
-        String signed = consumer.sign(GET_OAUTH1_URL + ticket);
-        HttpGet getOauth1 = new HttpGet(signed);
+        org.apache.http.client.methods.HttpGet request = new org.apache.http.client.methods.HttpGet(GET_OAUTH1_URL);
+        String signed = consumer.sign(GET_OAUTH1_URL);
+        HttpGet getOauth1 = new HttpGet(signed + "&accepts-mfa-tokens=true&ticket=" + ticket);
         HttpResponse response = httpclient.execute(getOauth1);
         String oauth1ResponseAsString = EntityUtils.toString(response.getEntity());
-        String oauth1Token = getOauth2FromResponse(oauth1ResponseAsString);
+        String oauth1Token = getOauth1FromResponse(oauth1ResponseAsString);
 
         // Exchange for oauth v2 token
         HttpPost postOauth2 = new HttpPost(GET_OAUTH2_URL);

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/GoogleFit.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/GoogleFit.java
@@ -89,10 +89,17 @@ public class GoogleFit {
   }
 
   private void buildFitnessClient() {
+    // These URIs were previously defined in Scopes.FITNESS_BODY_READ_WRITE and
+    // Scopes.FITNESS_ACTIVITY_READ_WRITE. Google removed these scopes from their current version of
+    // the APIs. The constants were determined from https://web.archive.org/web/20150909015924/https://developers.google.com/android/reference/com/google/android/gms/common/Scopes
+    // This is a quick fix. The REST API being used here is being removed after 30 June 2025, so
+    // this code will need to be removed soon anyway. See issue #74 (https://github.com/kochka/WeightLogger/issues/74)
+    final String FITNESS_BODY_READ_WRITE = "https://www.googleapis.com/auth/fitness.body.write";
+    final String FITNESS_ACTIVITY_READ_WRITE = "https://www.googleapis.com/auth/fitness.activity.write";
     mClient = new GoogleApiClient.Builder(getContext())
             .addApi(Fitness.HISTORY_API)
-            .addScope(new Scope(Scopes.FITNESS_BODY_READ_WRITE))
-            .addScope(new Scope(Scopes.FITNESS_ACTIVITY_READ_WRITE))
+            .addScope(new Scope(FITNESS_BODY_READ_WRITE))
+            .addScope(new Scope(FITNESS_ACTIVITY_READ_WRITE))
             .addConnectionCallbacks(
                     new GoogleApiClient.ConnectionCallbacks() {
                       @Override

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/PermissionHelper.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/PermissionHelper.java
@@ -2,8 +2,8 @@ package org.kochka.android.weightlogger.tools;
 
 import android.app.Activity;
 import android.content.pm.PackageManager;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
 public class PermissionHelper {
   private static final int PERMISSION_REQUEST_CODE = 1664;

--- a/app/src/main/java/org/kochka/android/weightlogger/tools/PermissionHelper.java
+++ b/app/src/main/java/org/kochka/android/weightlogger/tools/PermissionHelper.java
@@ -1,7 +1,11 @@
 package org.kochka.android.weightlogger.tools;
 
+import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
+
 import android.app.Activity;
 import android.content.pm.PackageManager;
+import android.os.Build;
+
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
@@ -27,7 +31,13 @@ public class PermissionHelper {
   }
 
   public void checkPermission(Activity activity, String permission) {
-    if (ContextCompat.checkSelfPermission(activity, permission) == PackageManager.PERMISSION_GRANTED) {
+    // If we are above the API version where this is required, we have access by default.
+    // This default permission is restrictive but sufficient for our needs.
+    if (permission.equals(WRITE_EXTERNAL_STORAGE) && Build.VERSION.SDK_INT >= 29) {
+      resultListener.onPermissionGranted(permission);
+    }
+    // If we are running on an older API version, we do need this permission
+    else if (ContextCompat.checkSelfPermission(activity, permission) == PackageManager.PERMISSION_GRANTED) {
       resultListener.onPermissionGranted(permission);
     }
     else {

--- a/app/src/main/res/drawable/baseline_arrow_back_24.xml
+++ b/app/src/main/res/drawable/baseline_arrow_back_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+    
+</vector>

--- a/app/src/main/res/layout/actionbar.xml
+++ b/app/src/main/res/layout/actionbar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.Toolbar
+<androidx.appcompat.widget.Toolbar
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:id="@+id/actionbar"
@@ -21,4 +21,4 @@
       android:indeterminate="true"
       android:visibility="gone" />
 
-</android.support.v7.widget.Toolbar>
+</androidx.appcompat.widget.Toolbar>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -6,7 +6,7 @@
                android:layout_width="match_parent"
                android:layout_height="match_parent">
     <ListView android:id="@+id/mListView" style="@style/List" />
-    <android.support.design.widget.FloatingActionButton style="@style/WrapWrap"
+    <com.google.android.material.floatingactionbutton.FloatingActionButton style="@style/WrapWrap"
       android:id="@+id/fab"
       android:layout_gravity="bottom|right"
       android:layout_margin="16dp"

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -62,9 +62,8 @@
   <string name="storage_not_mounted">La unitat d\'enregistrament no està muntada</string>
   <string name="network_error">Error de xarxa!</string>
   <string name="gc_configure_account">Has de configurar el teu compte Garmin Connect a les preferències!</string>
-  <string name="gc_account_error">Error de nom d\'usuari o de mot de pas Garmin Connect!</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">Normal</string>
   <string name="abnormal">Anormal</string>
   <string name="bf_underfat">Manca de pes</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -63,9 +63,8 @@
   <string name="storage_not_mounted">Uložiště není připojeno !</string>
   <string name="network_error">Síťová chyba !</string>
   <string name="gc_configure_account">Prosím nastavte Váš Garmin Connect účet v preferencích !</string>
-  <string name="gc_account_error">Chybné jméno nebo heslo pro Garmin Connect !</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">Normální</string>
   <string name="abnormal">Abnormální</string>
   <string name="bf_underfat">Málo tuku</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -63,9 +63,8 @@
   <string name="storage_not_mounted">Speicherkarte ist nicht eingelegt !</string>
   <string name="network_error">Netzwerkfehler !</string>
   <string name="gc_configure_account">Bitte Garmin Connect Konto konfigurieren !</string>
-  <string name="gc_account_error">Garmin Connect Benutzername oder Passwort falsch !</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">Normal</string>
   <string name="abnormal">Abnormal</string>
   <string name="bf_underfat">Untergewichtig</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -63,9 +63,8 @@
   <string name="storage_not_mounted">La unidad de salvado no está montada</string>
   <string name="network_error">Error de red!</string>
   <string name="gc_configure_account">Has de configurar tu cuenta Garmin Connect en las preferencias!</string>
-  <string name="gc_account_error">Error de nombre de usuario o contraseña Garmin Connect!</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">Normal</string>
   <string name="abnormal">Anormal</string>
   <string name="bf_underfat">Falta de peso</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -62,9 +62,8 @@
   <string name="storage_not_mounted">L\'espace de stockage n\'est pas monté</string>
   <string name="network_error">Erreur réseau !</string>
   <string name="gc_configure_account">Merci de configurer votre compte Garmin Connect dans les préférences !</string>
-  <string name="gc_account_error">Erreur de nom d\'utilisateur ou de mot de passe Garmin Connect !</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">Normal</string>
   <string name="abnormal">Anormal</string>
   <string name="bf_underfat">Maigreur</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -63,9 +63,8 @@
   <string name="storage_not_mounted">Scheda memoria non installata !</string>
   <string name="network_error">Errore di rete !</string>
   <string name="gc_configure_account">Perfavore configurate il vostro account per Garmin Connect nelle preferenze !</string>
-  <string name="gc_account_error">Nome utente o password per Garmin Connect non corrette !</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">Normopeso</string>
   <string name="abnormal">Anormale</string>
   <string name="bf_underfat">Sottopeso</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -63,9 +63,8 @@
   <string name="storage_not_mounted">זיכרון לא עלה (not mounted) !</string>
   <string name="network_error">שגיאת רשת !</string>
   <string name="gc_configure_account">נא להגדיר חשבון Garmin בתפריט העדפות !</string>
-  <string name="gc_account_error">שם משתמש או סיסמא שגויים !</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">רגיל</string>
   <string name="abnormal">חריג</string>
   <string name="bf_underfat">תת-שומן</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -63,9 +63,8 @@
   <string name="storage_not_mounted">ストレージがマウントされていません！</string>
   <string name="network_error">ネットワークエラー！</string>
   <string name="gc_configure_account">環境設定でお使いのGarmin Connectアカウントを設定してください！</string>
-  <string name="gc_account_error">ガーミンコネクトのユーザ名、またはパスワードが間違っています！</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">ノーマル</string>
   <string name="abnormal">不正</string>
   <string name="bf_underfat">やせている</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -63,9 +63,8 @@
   <string name="storage_not_mounted">Opslagruimte niet gemount !</string>
   <string name="network_error">Networkfout!</string>
   <string name="gc_configure_account">AUB uw Garmin Connect account instellen bij voorkeuren !</string>
-  <string name="gc_account_error">Foutieve Garmin Connect gebruikersnaam of wachtwoord !</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">Normaal</string>
   <string name="abnormal">Abnormaal</string>
   <string name="bf_underfat">Te lag vet</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -63,9 +63,8 @@
   <string name="storage_not_mounted">Katalog docelowy jest niedostępny!</string>
   <string name="network_error">Błąd połączenia!</string>
   <string name="gc_configure_account">Proszę skonfigurować w ustawieniach swoje konto Garmin Connect!</string>
-  <string name="gc_account_error">Błąd nazwy użytkownika lub hasła Garmin Connect!</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">Prawidłowy</string>
   <string name="abnormal">Nieprawodłowy</string>
   <string name="bf_underfat">Zbyt niski</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -63,9 +63,8 @@
   <string name="storage_not_mounted">Хранилище данных не смонтированно !</string>
   <string name="network_error">Ошибка сети !</string>
   <string name="gc_configure_account">Пожалуйста, настройте ваш аккаунт Garmin Connect в настройках !</string>
-  <string name="gc_account_error">Неверное имя пользователя или пароль Garmin Connect !</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">Нормально</string>
   <string name="abnormal">Ненормально</string>
   <string name="bf_underfat">Мало жира</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -63,9 +63,8 @@
   <string name="storage_not_mounted">Minnes arean är inte monterad !</string>
   <string name="network_error">Nätverks fel !</string>
   <string name="gc_configure_account">Vänligen konfigurera ditt Garmin Connect konto under inställningarna !</string>
-  <string name="gc_account_error">Felaktigt Garmin Connect användarnamn eller lösenord !</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">Normalvikt</string>
   <string name="abnormal">Abnormal</string>
   <string name="bf_underfat">Undervikt</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -63,9 +63,8 @@
   <string name="storage_not_mounted">Місце зберігання даних не встановлено !</string>
   <string name="network_error">Помилка мережі !</string>
   <string name="gc_configure_account">Будь ласка, налаштуйте свій аккаунт Garmin Connect в налаштуваннях !</string>
-  <string name="gc_account_error">Невірний логін або пароль Garmin Connect !</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">Нормально</string>
   <string name="abnormal">Ненормально</string>
   <string name="bf_underfat">Худорлявість</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -63,9 +63,8 @@
   <string name="storage_not_mounted">存储空间未挂载!</string>
   <string name="network_error">网络错误!</string>
   <string name="gc_configure_account">请在偏好设置中确认您的Garmin Connect帐号!</string>
-  <string name="gc_account_error">Garmin Connect帐号用户名或密码错误!</string>
-  
-  <!-- Show -->
+
+    <!-- Show -->
   <string name="normal">正常</string>
   <string name="abnormal">异常</string>
   <string name="bf_underfat">偏瘦</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -40,8 +40,8 @@
   </string-array>
 
   <string-array name="export_dir">
-    <item>/WeightLogger</item>
-    <item>/Android/data/org.kochka.android.weightlogger/files</item>
+    <item>~/Documents/WeightLogger</item>
+    <item>$appdata/org.kochka.android.weightlogger/files</item>
     <item>/Download/WeightLogger</item>
     <item>/Download</item>
   </string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
 
 <resources>
   <string name="app_name">Weight Logger</string>
-  <string name="app_version">2.4.2</string>
+  <string name="app_version">2.5.0-beta.1</string>
   <string name="translator"></string>
   
   <!-- Common -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,8 @@
   <string name="network_error">Network error !</string>
   <string name="gc_configure_account">Please configure your Garmin Connect account in preferences !</string>
   <string name="gc_account_error">Bad Garmin Connect username or password !</string>
+  <string name="gc_token_cleared">Cleared Garmin OAuth tokens!</string>
+  <string name="gc_token_clear_failed">Failed to clear Garmin OAuth tokens!</string>
   
   <!-- Show -->
   <string name="normal">Normal</string>
@@ -117,6 +119,8 @@
   <string name="pref_garmin_login_summary">Your Garmin Connect login.</string> 
   <string name="pref_garmin_password">Password</string>
   <string name="pref_garmin_password_summary">Your Garmin Connect password.</string>
+  <string name="pref_clear_garmin_token">Clear Garmin Tokens</string>
+  <string name="pref_clear_garmin_token_summary">Clear Garmin OAuth1 and OAuth2 Tokens. They will be regenerated on a successful login.</string>
   <string name="pref_database_category">Database</string>
   <string name="pref_backup_database">Backup database</string>
   <string name="pref_backup_database_summary">Backup database in export directory.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,7 +64,7 @@
   <string name="storage_not_mounted">Storage space is not mounted !</string>
   <string name="network_error">Network error !</string>
   <string name="gc_configure_account">Please configure your Garmin Connect account in preferences !</string>
-  <string name="gc_account_error">Bad Garmin Connect username or password !</string>
+  <string name="gc_account_error">Failed to log in to Garmin Connect!</string>
   <string name="gc_token_cleared">Cleared Garmin OAuth tokens!</string>
   <string name="gc_token_clear_failed">Failed to clear Garmin OAuth tokens!</string>
   

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
 
 <resources>
   <string name="app_name">Weight Logger</string>
-  <string name="app_version">2.5.0-beta.1</string>
+  <string name="app_version">2.5.0-beta.3</string>
   <string name="translator"></string>
   
   <!-- Common -->

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -14,6 +14,7 @@
   <PreferenceCategory android:title="@string/pref_garmin_category">
     <EditTextPreference android:key="garmin_login" android:title="@string/pref_garmin_login" android:summary="@string/pref_garmin_login_summary" android:singleLine="true" />
     <EditTextPreference android:key="garmin_password" android:title="@string/pref_garmin_password" android:summary="@string/pref_garmin_password_summary" android:password="true" android:singleLine="true" />
+    <Preference android:key="garmin_token_clear" android:title="@string/pref_clear_garmin_token" android:summary="@string/pref_clear_garmin_token_summary" />
   </PreferenceCategory>
 
   <PreferenceCategory android:title="@string/pref_database_category">

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,22 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:8.8.1'
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
+    }
+    configurations.all {
+        resolutionStrategy {
+            force('org.jetbrains.kotlin:kotlin-stdlib:1.8.22')
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 06 19:10:30 CET 2021
+#Sat Feb 15 12:30:27 NZDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/viewflow/build.gradle
+++ b/viewflow/build.gradle
@@ -1,11 +1,16 @@
 apply plugin: 'com.android.library'
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
+    namespace 'org.taptwo.android.widget.viewflow'
+    compileSdk 34
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 30
+        minSdkVersion 21
+        targetSdkVersion 35
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildTypes {
@@ -14,6 +19,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
+    buildToolsVersion '35.0.0'
 }
 
 dependencies {

--- a/viewflow/src/main/AndroidManifest.xml
+++ b/viewflow/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	android:versionCode="1" android:versionName="1.0" package="org.taptwo.android.widget.viewflow">
+	android:versionCode="1" android:versionName="1.0">
 	<application android:icon="@drawable/icon" android:label="@string/app_name">
 	</application>
-	<uses-sdk android:targetSdkVersion="8"/>
 </manifest> 


### PR DESCRIPTION
Fixes issues #59 , #68 and #70.
The changes were primarily discussed in #68.

Based on branch in PR #75 (as far as I can tell, GitHub doesn't support dependent PRs so all changes are included in this PR as well).

There is currently a known issue, which has caused me to mark this as a draft:

> If an OAuth token becomes invalid or is revoked before expiry, the user will be unable to upload until the token expiry date is reached or the application data is cleared. The OAuth1 token has a validity of 1 year, so neither option is desirable.

I encourage discussion on the best way to solve this. The options I see are:
- Add option in the settings to invalidate tokens (this is the most reliable option but may not be great for UX, though a prompt could be added)
- Automatically invalidate the tokens after a given number of failed login attempts (unrelated errors such as Garmin outages or network faults may invalidate tokens, requiring reauthentication, causing the user to have to re-enter MFA codes. If more than one failed attempt is required to invalidate the tokens, the reset process will be unintuitive)
- Automatically invalidate the tokens only when there is an authentication failure (this is the most user friendly option but may fail if Garmin change how they notify authentication failure or if different types of token invalidation result in different authentication failure messages)

The best solution is probably to combine the first and last options, invalidating the relevant token on a 401 error whilst also allowing the user to clear tokens in case they aren't automatically cleared.